### PR TITLE
Removes boost/cstdint

### DIFF
--- a/include/data/Data.hpp
+++ b/include/data/Data.hpp
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with Goblin Camp. If not, see <http://www.gnu.org/licenses/>.*/
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <ctime>
 
 namespace Data {
@@ -24,7 +24,7 @@ namespace Data {
 		std::string filename, size, date;
 		time_t timestamp; // for sorting
 		
-		Save(const std::string&, boost::uintmax_t, time_t);
+		Save(const std::string&, std::uintmax_t, time_t);
 	};
 	
 	// http://www.sgi.com/tech/stl/LessThanComparable.html

--- a/src/UI/DevConsole.cpp
+++ b/src/UI/DevConsole.cpp
@@ -18,7 +18,7 @@ along with Goblin Camp. If not, see <http://www.gnu.org/licenses/>.*/
 #include <libtcod.hpp>
 #include <string>
 #include <vector>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
 #include <algorithm>

--- a/src/data/Data.cpp
+++ b/src/data/Data.cpp
@@ -71,7 +71,7 @@ namespace {
 		\param[in]  filesize File size (in bytes).
 		\param[out] dest     A string buffer to receive formatted file size.
 	*/
-	void FormatFileSize(const boost::uintmax_t& filesize, std::string& dest) {
+	void FormatFileSize(const std::uintmax_t& filesize, std::string& dest) {
 		static const char* sizes[] = { "%10.0f b", "%10.2f kB", "%10.2f MB", "%10.2f GB" };
 		static unsigned maxSize = sizeof(sizes) / sizeof(sizes[0]);
 		
@@ -190,7 +190,7 @@ namespace {
 }
 
 namespace Data {
-	Save::Save(const std::string& filename, boost::uintmax_t size, time_t timestamp) : filename(filename), timestamp(timestamp) {
+	Save::Save(const std::string& filename, std::uintmax_t size, time_t timestamp) : filename(filename), timestamp(timestamp) {
 		FormatFileSize(size, this->size);
 		FormatTimestamp(timestamp, this->date);
 	}

--- a/src/tileRenderer/PermutationTable.cpp
+++ b/src/tileRenderer/PermutationTable.cpp
@@ -14,9 +14,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License 
 along with Goblin Camp. If not, see <http://www.gnu.org/licenses/>.*/
 
+#include <cstdint>
 #include "stdafx.hpp"
 #include "tileRenderer/PermutationTable.hpp"
- 
+
 PermutationTable::PermutationTable(int pow)
  : 	table(),
 	power(pow),
@@ -35,7 +36,7 @@ PermutationTable::PermutationTable(int pow)
 	}
 }
 
-PermutationTable::PermutationTable(int pow, uint32_t seed)
+PermutationTable::PermutationTable(int pow, std::uint32_t seed)
  : 	table(),
 	power(pow),
 	bitMask((1 << pow) - 1) 


### PR DESCRIPTION
Since we're using g++8 might as well take advantage of c++ std 17 and using std cstdint instead of boosts