### PR TITLE
Adding tools to help removing boost

### DIFF
--- a/tools/addlib.sh
+++ b/tools/addlib.sh
@@ -1,0 +1,25 @@
+#/usr/bin/env sh
+
+#
+#Add Library
+#
+#By Tony Sim (y2s82)
+#
+#Add STL library based on Boost couterpart object
+#This is a backup way to update library when removing boost
+#It should not be used unless boostrm.sh massed up
+#
+
+OBJ=$1
+TEMP=temp.temp
+for file in $(git grep -E $OBJ | sed -ne 's/^\([^:]*\):.*$/\1/p' | sort | uniq)
+do
+    if [[ $(echo $file | cut -d'.' -f2) = "hpp" ]]
+    then
+        sed -e "s/\(^.*#pragma once.*$\)/\1\n#include<memory>/" $file > $TEMP
+    elif [[ $(echo $file | cut -d'.' -f2) = "cpp" ]]
+    then
+        sed -e "s/\(^.*http:.*$\)/\1\n#include<memory>/" $file > $TEMP
+    fi
+    mv $TEMP $file
+done

--- a/tools/boostrm.sh
+++ b/tools/boostrm.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+
+#
+#Boost Remove
+#
+#By Tony Sim (y2s82)
+#
+#Requires: git grep mv sed sort uniq compatible-shell
+#
+#This is a dumb script that takes one argument: bash objects to change into its std:: counterpart
+#It will search for the object in all source code, and replace boost:: into std::
+#
+
+if [[ $# != 2 ]] 
+then
+    echo "USAGE: ./boostrm <object-name-or-extended-regex> <library-name>"
+    echo "The first argument is used by git grep with extended regular expression to find the boost libraries" 
+    echo "The second argument is for the #include<library-name> that should be added to get the std:: counterpart to run"
+    echo "E.g. ./boostrm weak_ptr memory"
+    echo "E.g. ./boostrm '(weak|shared)_ptr' memory"
+    exit 1
+fi
+
+OBJ=$(echo $1 | sed "s/boost:://") #filter the 1st argument to contain just the name of the object without a tag
+INC_LIB=$2 #the STL for the std:: version
+TEMP=temp.$RANDOM.$(date) #temporary file to store the changes
+
+
+for file in $(git grep -E $OBJ | sed -ne 's/^\([^:]*\):.*$/\1/p' | sort | uniq)
+do
+    sed\
+    -e "s%^.*#include.*<.*boost/$OBJ.hpp>.*$%#include <$INC_LIB>%"\ #replace the boost library with the STL library specified
+    -e "s/boost::$OBJ/std::$OBJ/g"\                                 #replace the boost:: tags with std:: tags for the given object specified
+    $file\
+    > $TEMP
+
+    mv $TEMP $file
+done


### PR DESCRIPTION
tools/boostrm.sh
This is a shell script.  It requires two arguments.  First argument is the name of the boost object to replace, and the second argument is the necessary STL library to run the object with std:: prefix.
This assumes the object name remains consistent between the two libraries.

toos/addlib.sh
This should not be used, but it is a backup way to add required library.  Added just for posterity of the code and should not be used if the boostrm.sh is used properly.